### PR TITLE
0.23 tweaks

### DIFF
--- a/outline.py
+++ b/outline.py
@@ -615,10 +615,6 @@ def check_temp_trophies(c, pmap):
   award_temp_trophy(c, pmap, query.player_rune_dive_best(c),
                     'rune_dive_rank:%d', [50, 20, 10], team_points=True)
 
-  award_temp_trophy(c, pmap, query.player_deaths_to_uniques_best(c),
-                    'deaths_to_uniques_Nth:%d', [50, 20, 10],
-                    can_share_places=False,
-                    team_points=True)
   # streak handling
   all_streaks = query.list_all_streaks(c)
   # not currently giving top_streak points

--- a/outline.py
+++ b/outline.py
@@ -627,7 +627,7 @@ def check_temp_trophies(c, pmap):
   # recompute all streaks yet again
   for streak in all_streaks:
     if streak[1] > 1:
-      assign_points(c, "streak", streak[0], streak[1]*100, False)
+      assign_points(c, "streak", streak[0], min(10, streak[1])*100, False)
     if streak[1] < 4:
       continue
     l = len(streak[3])

--- a/templates/all-players-10games.mako
+++ b/templates/all-players-10games.mako
@@ -1,0 +1,42 @@
+<%
+   import loaddb, query, crawl_utils, html
+
+   c = attributes['cursor']
+
+   stats = query.get_all_player_stats(c, max_games=10)
+ %>
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+          "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>10 game challenge</title>
+    <link rel="stylesheet" type="text/css" href="tourney-score.css">
+  </head>
+
+
+  <body class="page_back">
+    <div class="page">
+      <%include file="toplink.mako"/>
+
+      <div class="page_content">
+        <div class="heading_left">
+          <h1>10 game challenge</h1>
+        </div>
+
+        <hr>
+
+        <div class="page_content">How well can you do, playing 10 games or fewer during the tournament?</div>
+
+        <div class="content">
+          ${html.table_text( [ 'Player', 'Clan', 'Points',
+                               'Games Won', 'Games Played',
+                               'Win %' ],
+                             stats,
+                             place_column=2, skip=True )}
+        </div>
+      </div>
+    </div>
+    ${html.update_time()}
+  </body>
+</html>

--- a/templates/index.mako
+++ b/templates/index.mako
@@ -237,9 +237,9 @@ CUE, CWZ, CXC, LLD will take
             <p><span>5,000,000/turncount points</span> for each player's fastest win (by turncount).</p>
             <p><span>937,500/duration points</span> for each player's fastest win (by realtime, measured in seconds).</p>
             <p><span>score/120,000 points</span> for each player's highest scoring winning game.</p>
-            <p><span>100*length points</span> for each player's longest streak of length at least 2, where length of
+            <p><span>100*min(length points, 10)</span> for each player's longest streak of length at least 2, where length of
               a streak is defined as min(number of distinct species used, number
-              of distinct backgrounds used).</p>
+              of distinct backgrounds used).
             <div class="inset">
               <p>
                 Every game in a streak must be the first game you start after
@@ -254,6 +254,9 @@ CUE, CWZ, CXC, LLD will take
                 game B concurrently on two servers and win both in
                 succession to earn streak points. You can however have
                 multiple streaks in progress simultaneously.
+              </p>
+              <p>
+                Streak points are capped at 10-streaks (though the leaderboards will show streaks of any length). That is, the most points you can get for streaks during the tournament is 1000.
               </p>
             </div>
           </div>
@@ -918,10 +921,13 @@ III: Win a game as a non-demigod without worshipping a god.
             <h2>CHANGED RULES</h2>
             <hr>
             <div class="fineprint">
+              <p><span class="added">[NEW]</span>
+                The 10 game challenge scoreboard has been added.</p>
               <p>
-		All rules are the same as the 0.22 tournament held in August
-                2018.
-                The 10 game challenge scoreboard has been added.
+              <p><span class="changed">[CHANGED]</span>
+                Points for streaking have been capped at 10-streaks for the 0.23
+                tournament. (Leaderboard streak displays are unchanged.)
+              </p>
               </p>
               <!--
               <p><span class="removed">[REMOVED]</span>

--- a/templates/index.mako
+++ b/templates/index.mako
@@ -376,6 +376,14 @@ CUE, CWZ, CXC, LLD will take
           <hr>
 
           <div>
+            <h3>10 game challenge</h3>
+            <p>
+              The 10 game challenge is a leaderboard for players who complete 10 or fewer games during the tournament. All points for those games apply in the usual way, but players with more than 10 games will not be ranked on this leaderboard.
+            </p>
+          </div>
+
+
+          <div>
             <h3>CONDUCT</h3>
             <p>
               Please do not do anything that would give you an unfair competitive advantage over other players or clans. This includes stuff like scumming crash-on-demand bugs or running bots on your own account for speedrun points &ndash; just remember that the objective here is to have fun. (You are welcome to run bots on their own accounts in the tourney, though as always on online servers you should be careful not to hammer the CPU with them. Also, bot wins will not be displayed on lists of fastest wins.)
@@ -913,6 +921,7 @@ III: Win a game as a non-demigod without worshipping a god.
               <p>
 		All rules are the same as the 0.22 tournament held in August
                 2018.
+                The 10 game challenge scoreboard has been added.
               </p>
               <!--
               <p><span class="removed">[REMOVED]</span>

--- a/templates/index.mako
+++ b/templates/index.mako
@@ -377,7 +377,7 @@ CUE, CWZ, CXC, LLD will take
           <hr>
 
           <div>
-            <h3>10 game challenge</h3>
+            <h3>10 GAME CHALLENGE</h3>
             <p>
               The 10 game challenge is a leaderboard for players who complete 10 or fewer games during the tournament. All points for those games apply in the usual way, but players with more than 10 games will not be ranked on this leaderboard.
             </p>
@@ -929,7 +929,6 @@ III: Win a game as a non-demigod without worshipping a god.
               <p><span class="removed">[REMOVED]</span>
                 Bonuses for being the first to kill the most distinct uniques have been removed.</p>
               <!--
-              
 
               <p><span class="added">[NEW]</span>
                 flags rules that are new to this tournament.</p>

--- a/templates/index.mako
+++ b/templates/index.mako
@@ -157,8 +157,6 @@ CUE, CWZ, CXC, LLD will take
             <p><span>5 points</span> the first time you kill each
               unique.</p>
 
-            <p><span>50-20-10 points</span> for the players with the most distinct
-            uniques killed; ties broken by who gets that number first.</p>
             <h5>HIGH SCORES</h5>
             <p>
               <span>5 points</span> per high score in a species/background combination
@@ -921,18 +919,17 @@ III: Win a game as a non-demigod without worshipping a god.
             <h2>CHANGED RULES</h2>
             <hr>
             <div class="fineprint">
+            <p>This tournament contains some minor rule changes designed to eliminate certain incentives for grinding.</p>
               <p><span class="added">[NEW]</span>
                 The 10 game challenge scoreboard has been added.</p>
-              <p>
               <p><span class="changed">[CHANGED]</span>
                 Points for streaking have been capped at 10-streaks for the 0.23
                 tournament. (Leaderboard streak displays are unchanged.)
               </p>
-              </p>
-              <!--
               <p><span class="removed">[REMOVED]</span>
-                flags rules that existed in the 0.22 tournament and are gone in
-                this tournament.</p>
+                Bonuses for being the first to kill the most distinct uniques have been removed.</p>
+              <!--
+              
 
               <p><span class="added">[NEW]</span>
                 flags rules that are new to this tournament.</p>

--- a/templates/player.mako
+++ b/templates/player.mako
@@ -107,7 +107,12 @@
                 <th>Rank</th>
                 <td>${stats['rank1']} / ${stats['rank2']}</td>
               </tr>
-
+              %if stats['10game_rank']:
+                <tr>
+                  <th>10-game challenge rank:</th>
+                  <td>${stats['10game_rank']} / ${stats['10game_rank2']}</td>
+                </tr>
+              %endif
               <tr>
                 <th>Tourney team points</th>
                 <td class="numeric">${stats['team_points']}</td>

--- a/templates/toplink.mako
+++ b/templates/toplink.mako
@@ -18,5 +18,7 @@
 &nbsp;
 <a href="${XXX_TOURNEY_BASE}/current-games.html">Current Games</a>
 &nbsp;
+<a href="${XXX_TOURNEY_BASE}/all-players-10games.html">10-game challenge</a>
+&nbsp;
 <a href="${XXX_TOURNEY_BASE}">Rules</a>
 </div>

--- a/update_page.py
+++ b/update_page.py
@@ -45,6 +45,7 @@ def player_pages(c):
   render(c, 'species-backgrounds')
   render(c, 'banners')
   render(c, 'all-players')
+  render(c, 'all-players-10games')
   render(c, 'wins-and-kills')
   render(c, 'current-games')
   render(c, 'combo-scoreboard')


### PR DESCRIPTION
Here are some possible adjustments for the 0.23 tourney pages and rules, no requirement that we use them all, but I did some of the ones on minmay's list (see [this thread](https://crawl.develz.org/tavern/viewtopic.php?f=8&t=25660)) that were the easiest to do, and also seemed to me to matter not so much for relatively casual players.

This PR also includes a new scoreboard for players who have no more than 10 games total during the tournament. This is aimed at decent and casual players who don't have much time to play, but I think it could also be interesting for strong players who want to approach limited play-time strategically.