### PR TITLE
Initial restyling

### DIFF
--- a/html.py
+++ b/html.py
@@ -505,7 +505,7 @@ def games_table(games, first=None, excluding=None, columns=None,
   last_value = None
 
   for game in games:
-    row_class = "table-secondary text-dark" if game.get('killertype') == 'winning' else ""
+    row_class = "table-secondary" if game.get('killertype') == 'winning' else ""
 
     out += '''<tr class="%s">''' % row_class
 

--- a/templates/base.mako
+++ b/templates/base.mako
@@ -37,14 +37,14 @@
 
   <body class="text-light">
     <a class="sr-only sr-only-focusable" href="#content">Skip to main content</a>
-    <nav class="navbar navbar-dark navbar-expand-lg" style="background-color: #1a1a1a;">
+    <nav class="navbar navbar-dark navbar-expand-lg">
       <a class="navbar-brand overflow-hidden" href="${XXX_TOURNEY_BASE}">
         <img src="${XXX_IMAGE_BASE}/stone_soup_icon-32x32.png" class="pixel-art mr-1 align-top" width="32" height="32" alt="">
         Dungeon Crawl Stone Soup ${T_VERSION} Tournament
       </a>
     </nav>
     ## The background of this bar is deliberately different
-    <nav class="navbar navbar-expand-lg navbar-dark sticky-top" style="background-color: black;">
+    <nav class="navbar navbar-expand-lg navbar-dark sticky-top">
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/templates/clan.mako
+++ b/templates/clan.mako
@@ -71,7 +71,7 @@
         </thead>
         <tbody>
           ## First row shows total score
-          <tr class="table-secondary text-dark">
+          <tr class="table-secondary">
             <th scope="row">
               <a href="${base_link('teams.html')}">
                 Total

--- a/templates/combo-scoreboard.mako
+++ b/templates/combo-scoreboard.mako
@@ -44,7 +44,7 @@
     <div class="col">
     <h2>Background Scoreboard</h2>
       <p class="lead">
-        Highest scoring game for each backgroudn played in the tournament.
+        Highest scoring game for each background played in the tournament.
       </p>
       ${class_scores_text}
     </div>

--- a/templates/player-individual-categories.mako
+++ b/templates/player-individual-categories.mako
@@ -19,7 +19,7 @@
   </thead>
   <tbody>
     ## First row shows total score
-    <tr class="table-secondary text-dark">
+    <tr class="table-secondary">
       <th scope="row">
         <a href="${base_link('all-players-ranks.html')}">
           Total

--- a/templates/player-individual-categories.mako
+++ b/templates/player-individual-categories.mako
@@ -40,7 +40,7 @@
         %>
         ${'{:,}'.format(points)}
       </th>
-      <th scope="row"></th>
+      <!--<th scope="row"></th>-->
     </tr>
   % for category in scoring_data.INDIVIDUAL_CATEGORIES:
   <%

--- a/templates/style.css
+++ b/templates/style.css
@@ -1,22 +1,58 @@
 body {
-  background-color: #322;
+  background-color: #282020;
 }
 
-nav:nth-of-type(2) {
-  background-color: #211;
+body > nav:nth-of-type(2) {
+  background-color: #181010;
+}
+
+.bg-dark {
+  background-color: #434 !important;;
+}
+
+.text-light {
+  color: #eee !important;
+}
+
+.text-dark {
+  color: #322 !important;
+}
+
+.text-light a {
+  /* Increase link contrast with our background */
+  color: #8ee;
+}
+
+.text-dark a {
+/*  color: #21a; */ /* in case link color is hard to read*/
+}
+
+code {
+  color: #aea;
+  font-weight: 600;
+}
+
+.alert-dark {
+  background-color: #434;
+  border-color: #ff8;
+}
+
+.alert-dark.text-dark {
+  color: #eee !important;
 }
 
 .nav-tabs {
-  border-color: #444;
+  border-color: #7d623c;
+  border-bottom-width: 2px;
 }
 
 .nav-tabs .nav-link:hover {
-  border-color: #444;
+  border-color: #7d623c;
 }
 
 .nav-tabs .nav-link.active {
-  background-color: #533;
-  border-color: #444;
+  background-color: #383030;
+  border-color: #7d623c;
   color: #eee;
 }
 
@@ -49,41 +85,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Make sticky column background dark. Without this, the columns assume Bootstrap light colour */
 table.DTFC_Cloned th, table.DTFC_Cloned td {
-  background-color: #433;
-}
-
-.bg-dark {
-  background-color: #434 !important;;
-}
-
-.text-light {
-  color: #eee !important;;
-}
-
-.text-dark {
-  color: #322 !important;
-}
-
-.text-light a {
-  /* Increase link contrast with our background */
-  color: #8ff;
-}
-
-.text-dark a {
-/*  color: #21a; */ /* in case link color is hard to read*/
-}
-
-code {
-  color: #afa;
-}
-
-.alert-dark {
-  background-color: #434;
-  border-color: #ff8;
-}
-
-.alert-dark.text-dark {
-  color: #eee !important;
+  background-color: #303030;
 }
 
 div.banner img {
@@ -94,39 +96,43 @@ div.banner img {
 
 hr {
   /* Slightly lighter <hr>s, to suit our dark background. */
-  border-top: 1px solid rgba(64, 64, 64, 0.5);
+  border-top: 2px solid #7d623c;
 }
 
 .table-dark thead tr, .table-dark tbody tr, .table-dark.table-striped tbody tr {
-  background-color: #533;
+  background-color: #303030;
 }
 
 .table-dark.table-striped tbody tr:nth-of-type(2n+1) {
-  background-color: #433;
+  background-color: #404040;
 }
 
 .table-dark.table-hover tbody tr:hover > td, .table-dark.table-hover tbody tr:hover > th {
-  background-color: #733;
+  background-color: #505050;
 }
 
 .table-secondary > td {
-  background-color: #4b4;
+  background-color: #272;
 }
 
 .table-striped .table-secondary:nth-child(2n) > td {
-  background-color: #3a3;
+  background-color: #262;
 }
 
 .table-dark.table-hover .table-secondary:hover > td {
-  background-color: #5c5;
+  background-color: #383;
 }
 
 .table-secondary > th {
-  background-color: #434;
+  background-color: #7d623c;
 }
 
-.table-hover .table-secondary:hover > th {
-  background-color: #435;
+.table-dark.table-hover .table-secondary:hover > th {
+  background-color: #7d623c;
+}
+
+.table-dark td, .table-dark th, .table-dark thead th {
+  border-color: #7d623c;
 }
 
 /* XX hack workaround, restore the bootstrap styling (otherwise table-dark
@@ -146,41 +152,41 @@ table.dataTable tbody tr {
 }
 
 .form-control, .custom-select, .custom-select:focus {
-  background-color: #433;
+  background-color: #303030;
   color: #eee;
-  border-color: #888;
+  border-color: #7d623c;
 }
 
 .form-control:focus {
-  background-color: #533;
+  background-color: #202020;
   color: #eee;
 }
 
 input {
-  background-color: #211;
+  background-color: #101010;
   color: #eee;
 }
 
 .page-link {
-  background-color: #533;
+  background-color: #303030;
   color: #eee;
-  border-color: #444;
+  border-color: #7d623c;
 }
 
 .page-link:hover {
-  background-color: #833;
+  background-color: #434;
   color: #eee;
-  border-color: #444;
+  border-color: #7d623c;
 }
 
 .page-item.disabled .page-link {
-  background-color: #433;
-  border-color: #444;
+  background-color: #282020;
+  border-color: #7d623c;
 }
 
 .page-item.active .page-link {
-  background-color: #833;
-  border-color: #444;
+  background-color: #757;
+  border-color: #7d623c;
 }
 
 .pagination {
@@ -222,5 +228,5 @@ input {
 }
 
 .search-list li a:hover {
-  background-color: #343434;
+  background-color: #434;
 }

--- a/templates/style.css
+++ b/templates/style.css
@@ -1,5 +1,23 @@
 body {
-  background-color: #1a1a1a;
+  background-color: #322;
+}
+
+nav:nth-of-type(2) {
+  background-color: #211;
+}
+
+.nav-tabs {
+  border-color: #444;
+}
+
+.nav-tabs .nav-link:hover {
+  border-color: #444;
+}
+
+.nav-tabs .nav-link.active {
+  background-color: #533;
+  border-color: #444;
+  color: #eee;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -31,12 +49,41 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Make sticky column background dark. Without this, the columns assume Bootstrap light colour */
 table.DTFC_Cloned th, table.DTFC_Cloned td {
-  background-color: #343a40;
+  background-color: #433;
+}
+
+.bg-dark {
+  background-color: #434 !important;;
+}
+
+.text-light {
+  color: #eee !important;;
+}
+
+.text-dark {
+  color: #322 !important;
 }
 
 .text-light a {
   /* Increase link contrast with our background */
-  color: #72a6f8;
+  color: #8ff;
+}
+
+.text-dark a {
+/*  color: #21a; */ /* in case link color is hard to read*/
+}
+
+code {
+  color: #afa;
+}
+
+.alert-dark {
+  background-color: #434;
+  border-color: #ff8;
+}
+
+.alert-dark.text-dark {
+  color: #eee !important;
 }
 
 div.banner img {
@@ -48,6 +95,38 @@ div.banner img {
 hr {
   /* Slightly lighter <hr>s, to suit our dark background. */
   border-top: 1px solid rgba(64, 64, 64, 0.5);
+}
+
+.table-dark thead tr, .table-dark tbody tr, .table-dark.table-striped tbody tr {
+  background-color: #533;
+}
+
+.table-dark.table-striped tbody tr:nth-of-type(2n+1) {
+  background-color: #433;
+}
+
+.table-dark.table-hover tbody tr:hover > td, .table-dark.table-hover tbody tr:hover > th {
+  background-color: #733;
+}
+
+.table-secondary > td {
+  background-color: #4b4;
+}
+
+.table-striped .table-secondary:nth-child(2n) > td {
+  background-color: #3a3;
+}
+
+.table-dark.table-hover .table-secondary:hover > td {
+  background-color: #5c5;
+}
+
+.table-secondary > th {
+  background-color: #434;
+}
+
+.table-hover .table-secondary:hover > th {
+  background-color: #435;
 }
 
 /* XX hack workaround, restore the bootstrap styling (otherwise table-dark
@@ -64,6 +143,48 @@ table.dataTable tbody tr {
 
 .lr-flex > div {
   width: 48%;
+}
+
+.form-control, .custom-select, .custom-select:focus {
+  background-color: #433;
+  color: #eee;
+  border-color: #888;
+}
+
+.form-control:focus {
+  background-color: #533;
+  color: #eee;
+}
+
+input {
+  background-color: #211;
+  color: #eee;
+}
+
+.page-link {
+  background-color: #533;
+  color: #eee;
+  border-color: #444;
+}
+
+.page-link:hover {
+  background-color: #833;
+  color: #eee;
+  border-color: #444;
+}
+
+.page-item.disabled .page-link {
+  background-color: #433;
+  border-color: #444;
+}
+
+.page-item.active .page-link {
+  background-color: #833;
+  border-color: #444;
+}
+
+.pagination {
+  border-color: #000;
 }
 
 #player-search-div {

--- a/templates/style.css
+++ b/templates/style.css
@@ -112,15 +112,15 @@ hr {
 }
 
 .table-secondary > td {
-  background-color: #272;
+  background-color: #242;
 }
 
 .table-striped .table-secondary:nth-child(2n) > td {
-  background-color: #262;
+  background-color: #252;
 }
 
 .table-dark.table-hover .table-secondary:hover > td {
-  background-color: #383;
+  background-color: #363;
 }
 
 .table-secondary > th {

--- a/templates/style.css
+++ b/templates/style.css
@@ -112,11 +112,11 @@ hr {
 }
 
 .table-secondary > td {
-  background-color: #242;
+  background-color: #252;
 }
 
 .table-striped .table-secondary:nth-child(2n) > td {
-  background-color: #252;
+  background-color: #242;
 }
 
 .table-dark.table-hover .table-secondary:hover > td {


### PR DESCRIPTION
Here's a quick pass at styling the website. Mostly I have only edited style.css except for removing styles coded in the html and some text-dark classes. **This hasn't been fully tested by running the python server, only the css has been tested with firefox dev tools.** If someone with the tournament scripts already set up could pull and test that would be great.

All the colors I chose are basic 3 digit hex values (e.g. #322 background) which were chosen very quickly and roughly, feel free to edit them.

<img width="741" alt="Screen Shot 2020-06-12 at 3 47 58 PM" src="https://user-images.githubusercontent.com/2109690/84466230-0af01200-accd-11ea-8f73-6b8c3a8c110f.png">
<img width="747" alt="Screen Shot 2020-06-12 at 3 40 02 PM" src="https://user-images.githubusercontent.com/2109690/84466232-0e839900-accd-11ea-95f0-a312c6fd2aa5.png">
<img width="981" alt="Screen Shot 2020-06-12 at 3 08 44 PM" src="https://user-images.githubusercontent.com/2109690/84466234-0f1c2f80-accd-11ea-86d7-585e6bd1b2d7.png">
<img width="1114" alt="Screen Shot 2020-06-12 at 1 31 26 PM" src="https://user-images.githubusercontent.com/2109690/84466237-104d5c80-accd-11ea-94e3-820b9a66c393.png">
<img width="1134" alt="Screen Shot 2020-06-12 at 1 31 08 PM" src="https://user-images.githubusercontent.com/2109690/84466239-10e5f300-accd-11ea-8992-03970a2051ce.png">
<img width="1135" alt="Screen Shot 2020-06-12 at 1 30 48 PM" src="https://user-images.githubusercontent.com/2109690/84466241-12172000-accd-11ea-9546-7c4ef7f5bfee.png">
<img width="1006" alt="Screen Shot 2020-06-12 at 3 53 16 PM" src="https://user-images.githubusercontent.com/2109690/84466244-12172000-accd-11ea-91ae-aec0ecd969fb.png">
