### PR TITLE
Adjust Trog banner to ban entry into other rune branches than Vaults/Tomb/Abyss

### DIFF
--- a/outline.py
+++ b/outline.py
@@ -129,11 +129,6 @@ def do_milestone_rune(c, mile):
     banner.award_banner(c, player, 'ashenzari', 3)
   elif runes_found >= 5:
     banner.award_banner(c, player, 'ashenzari', 2)
-  if mile['urune'] == 1:
-    if rune == 'silver':
-      banner.award_banner(c, player, 'trog', 2)
-    elif rune == 'golden':
-      banner.award_banner(c, player, 'trog', 3)
   if rune == 'golden' and num_rune == 1:
     banner.award_banner(c, player, 'fedhas', 2)
   if rune == 'silver' and num_rune == 1:
@@ -156,6 +151,19 @@ def do_milestone_rune(c, mile):
         break
     if eligible:
       banner.award_banner(c, player, 'gozag', 3)
+
+  if mile['urune'] == 1:
+    other_rune_branches = ['Shoals', 'Snake', 'Spider', 'Swamp', 'Slime', 'Pan', 'Coc', 'Geh', 'Tar', 'Dis']
+    eligible = True
+    for br in other_rune_branches:
+      if query.did_enter_branch(c, br, player, mile['start'], mile['time']):
+        eligible = False
+        break
+    if eligible:
+      if rune == 'silver':
+        banner.award_banner(c, player, 'trog', 2)
+      elif rune == 'golden':
+        banner.award_banner(c, player, 'trog', 3)
 
   if nemelex.is_nemelex_choice(mile['char'], mile['time']):
     banner.award_banner(c, player, 'nemelex', 2)

--- a/scoring_data.py
+++ b/scoring_data.py
@@ -1072,8 +1072,8 @@ BANNERS = [
         "Rage",
         BannerTiers(
             "Enter the Vaults with no runes.",
-            "Pick up the silver rune before any other runes.",
-            "Pick up the golden rune before any other runes.",
+            "Pick up the silver rune as your first rune before any entering any other rune branch than Vaults, Tomb or Abyss.",
+            "Pick up the golden rune as your first rune before any entering any other rune branch than Vaults, Tomb or Abyss.",
         ),
         'Trog thinks players should stop bothering with the lair and take their <code>RAGE</code> to where the most magic is as soon as possible.',
         "trog",

--- a/tourney_html.py
+++ b/tourney_html.py
@@ -125,8 +125,8 @@ BANNER_TEXT = \
         ],
       'trog':
         [ 'Enter the Vaults with no runes.',
-          'Pick up the silver rune before any other runes.',
-          'Pick up the golden rune before any other runes.',
+          'Pick up the silver rune as your first rune before any entering any other rune branch than Vaults, Tomb or Abyss.',
+          'Pick up the golden rune as your first rune before any entering any other rune branch than Vaults, Tomb or Abyss.',
         ],
       'the_shining_one':
         [ 'Kill Sigmund before entering the Depths.',


### PR DESCRIPTION
In the last tournament, this banner was fairly trivialized, as players would simply clear Lair branches with autopickup disabled, avoid touching the rune but grabbing all of the loot and experience, and then clear Vaults:5/Tomb at a time where they have normally progressed to tackle these areas.

This defeats the purpose of the banner of being locked earlier than expected in a hostile, overleveled area.

This patch makes the Trog banner of tiers 2 & 3 similar to the Gozag 3 banner, where instead of rushing for the Iron Rune, contenders must enter the Vaults with no runes and having not entered any rune branches other than Vaults, Tomb or Abyss, then claim the silver or golden rune respectively.